### PR TITLE
Respecting safe area insets for scroll views

### DIFF
--- a/Source/Classes/Internal/Extensions/UIScrollViiew+Utils.swift
+++ b/Source/Classes/Internal/Extensions/UIScrollViiew+Utils.swift
@@ -14,10 +14,24 @@ extension UIScrollView {
     }
 
     var isContentOriginInBounds: Bool {
-        return contentOffset.y <= -contentInset.top
+        return contentOffset.y <= -oc_adjustedContentInset.top
     }
 
     func scrollToTop() {
-        contentOffset.y = -contentInset.top
+        contentOffset.y = -oc_adjustedContentInset.top
+    }
+}
+
+
+extension UIScrollView {
+    
+    var oc_adjustedContentInset: UIEdgeInsets {
+        
+        if #available(iOS 11.0, *) {
+            return self.adjustedContentInset
+        } else {
+            // Fallback on earlier versions
+            return self.contentInset
+        }
     }
 }

--- a/Source/Classes/Internal/ScrollViewOverlayTranslationDriver.swift
+++ b/Source/Classes/Internal/ScrollViewOverlayTranslationDriver.swift
@@ -68,10 +68,10 @@ class ScrollViewOverlayTranslationDriver: OverlayTranslationDriver, OverlayScrol
         scrollView.panGestureRecognizer.setTranslation(.zero, in: nil)
         // (gz) 2018-01-24 We adjust the content offset and the velocity only if the overlay will be dragged.
         switch controller.translationPosition {
-        case .bottom where targetContentOffset.pointee.y > -scrollView.contentInset.top:
+        case .bottom where targetContentOffset.pointee.y > -scrollView.oc_adjustedContentInset.top:
             // (gz) 2018-11-26 The user raises its finger in the bottom position
             // and the content offset will exceed the top content inset.
-            targetContentOffset.pointee.y = -scrollView.contentInset.top
+            targetContentOffset.pointee.y = -scrollView.oc_adjustedContentInset.top
         case .inFlight where !controller.overlayHasReachedANotch():
             targetContentOffset.pointee.y = lastContentOffsetWhileScrolling.y
         case .top, .bottom, .inFlight, .stationary:
@@ -109,7 +109,7 @@ class ScrollViewOverlayTranslationDriver: OverlayTranslationDriver, OverlayScrol
     private func adjustedContentOffset(dragging scrollView: UIScrollView) -> CGPoint {
         guard let controller = translationController else { return .zero }
         var contentOffset = lastContentOffsetWhileScrolling
-        let topInset = -scrollView.contentInset.top
+        let topInset = -scrollView.oc_adjustedContentInset.top
         switch controller.translationPosition {
         case .inFlight, .top:
             // (gz) 2018-11-26 The user raised its finger in the top or in flight positions while scrolling bottom.


### PR DESCRIPTION
When showing an overlay that contains a view controller with a scroll view (eg UITableViewController) that has `contentInsetAdjustmentBehavior` set to `automatic` (which is the default since iOS 11) and that controller is embedded inside a container view controller with bars (eg. UINavigationController) or a view controller that sets `additionalSafeAreaInsets` - the overlay does not respect the safe are insets when the user moves the overlay.

The issue results to scroll view content being covered by navigation bars and not being adjusted correctly, due to wrong calculations, not honoring the `adjustedContentInset`.

Wrong           |  Correct
:-------------------------:|:-------------------------:
![navigation_bar_wrong](https://user-images.githubusercontent.com/1181346/63386953-e7aa4e00-c3ac-11e9-83dd-51706565620f.png)  |  ![navigationbar_correct](https://user-images.githubusercontent.com/1181346/63386954-e7aa4e00-c3ac-11e9-90ad-82126b4fe145.png)

The solution to the issue to start using `adjustedContentInset` of UIScrollView instead of `contentInsets` when calculating and performing the dragging behavior.

Since `adjustedContentInset` is available from iOS11+ -> it has to be used safely. 
This PR perform this change by wrapping the content insets of the scroll view in a safe backward compatible manner and updates any usage of them in ScrollViewOverlayTranslationDriver.