### PR TITLE
Annotate UIKit-bound controllers with @MainActor for Swift 6

### DIFF
--- a/Source/OverlayContainer/Internal/Extensions/UIViewController+Children.swift
+++ b/Source/OverlayContainer/Internal/Extensions/UIViewController+Children.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+@MainActor
 extension UIViewController {
     func addChild(_ child: UIViewController, in containerView: UIView) {
         guard containerView.isDescendant(of: view) else { return }

--- a/Source/OverlayContainer/Internal/HeightContraintOverlayTranslationController.swift
+++ b/Source/OverlayContainer/Internal/HeightContraintOverlayTranslationController.swift
@@ -36,6 +36,7 @@ protocol HeightConstraintOverlayTranslationControllerDelegate: AnyObject {
     func translationControllerDidScheduleTranslations(_ translationController: OverlayTranslationController)
 }
 
+@MainActor
 class HeightConstraintOverlayTranslationController: OverlayTranslationController {
 
     weak var delegate: HeightConstraintOverlayTranslationControllerDelegate?

--- a/Source/OverlayContainer/Internal/InterruptibleAnimatorOverlayContainerTransitionCoordinator.swift
+++ b/Source/OverlayContainer/Internal/InterruptibleAnimatorOverlayContainerTransitionCoordinator.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+@MainActor
 class InterruptibleAnimatorOverlayContainerTransitionCoordinator: OverlayContainerTransitionCoordinator {
 
     private let animator: UIViewImplicitlyAnimating


### PR DESCRIPTION
## Summary
- mark UIKit-facing helper extensions and controllers as `@MainActor`
- fixes Swift 6 `SWIFT_STRICT_CONCURRENCY=complete` builds by allowing constraint updates and animator callbacks on the main actor

## Details
Building with Swift 6.2 and `SWIFT_SUPPRESS_WARNINGS=NO` currently fails due to main-actor isolation violations in:
- `UIViewController+Children.swift` (helper methods used by container)
- `HeightContraintOverlayTranslationController.swift` (mutates `NSLayoutConstraint`)
- `InterruptibleAnimatorOverlayContainerTransitionCoordinator.swift` (animator callbacks)

Adding `@MainActor` to these types brings them in line with UIKit’s main-thread requirement and resolves the concurrency errors. Behavior is unchanged; only actor isolation is specified explicitly.

Tested: builds cleanly on Swift 6.2 simulator with strict concurrency.
